### PR TITLE
The first quantum networks may not be "routing and forwarding" networks.

### DIFF
--- a/draft-irtf-qirg-principles-03.txt
+++ b/draft-irtf-qirg-principles-03.txt
@@ -102,7 +102,7 @@ Table of Contents
      5.4.  Network boundaries  . . . . . . . . . . . . . . . . . . .  19
        5.4.1.  Boundaries between different physical architectures .  19
        5.4.2.  Boundaries between different administrative regions .  19
-     5.5.  Physical constraints  . . . . . . . . . . . . . . . . . .  19
+     5.5.  Physical constraints  . . . . . . . . . . . . . . . . . .  20
        5.5.1.  Memory lifetimes  . . . . . . . . . . . . . . . . . .  20
        5.5.2.  Rates . . . . . . . . . . . . . . . . . . . . . . . .  20
        5.5.3.  Communication qubits  . . . . . . . . . . . . . . . .  20
@@ -122,7 +122,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
    9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
    10. Informative References  . . . . . . . . . . . . . . . . . . .  26
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  27
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
 1.  Introduction
 
@@ -795,12 +795,12 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        differences between quantum networks and classical networks.
 
        Classical networks have routing and forwarding; routing decides
-       the way to go and forwarding executes actual data transfer,
-       obeying the decision.  Quantum networks execute routing in a
+       the way to go, and forwarding executes actual data transfer,
+       obeying the decision.  Quantum networks perform routing in a
        control plane and execute entanglement swapping instead of
        forwarding in a data plane.  Such quantum networks are "routing
        and swapping" networks.  In "routing and swapping" networks, we
-       do not need to care the order of generating link Bell pairs,
+       do not need to care about the order of generating link Bell pairs
        since Bell pairs are undirected resources.  This distinction
        makes control algorithms and optimization of quantum networks
        different from classical ones.  Additionally, "routing and
@@ -814,13 +814,15 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        Entanglement swapping is a specific algorithm for a set of Bell
        pairs.  More algorithms to build a quantum network from Bell
        pairs have been proposed.  "Routing and measuring" is a broader
-       category and more types of quantum networks should belong to it.
+       category, and more types of quantum networks will be categorized
+       into it.
 
        Meanwhile, quantum networks of direct transmission are "routing
        and forwarding" networks.  Such quantum networks can carry
-       arbitrary states hop by hop.  Therefore they are also "store and
-       forward" networks, in contrast to "routing and swapping" quantum
-       networks.
+       arbitrary states hop by hop, therefore they are also "store and
+       forward" networks.  Hence direct transmission quantum network
+       could be more similar to classical networks in networking
+       algorithms.
 
    3.  An entangled pair is only useful if the locations of both qubits
        are known.
@@ -831,9 +833,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        to anybody else in the network.  The packet can be simply
        forwarded as before.
 
-       In contrast, entanglement is a phenomenon in which two or more
-       qubits exist in a physically distributed state.  Operations on
-       one of the qubits change the mutual state of the pair.  Since the
+
 
 
 
@@ -842,6 +842,9 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 15]
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+       In contrast, entanglement is a phenomenon in which two or more
+       qubits exist in a physically distributed state.  Operations on
+       one of the qubits change the mutual state of the pair.  Since the
        owner of a particular qubit cannot just read out its state, it
        must coordinate all its actions with the owner of the pair's
        other qubit.  Therefore, the owner of any qubit that is part of
@@ -887,9 +890,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    domain limts).  Therefore, quantum routers will need to manage two
    data planes in parallel, a classical one and a quantum one.
    Additionally, it must be able to correlate information between them
-   so that the control information received on a classical channel can
-   be applied to the qubits managed by the quantum data plane.
-
 
 
 
@@ -897,6 +897,9 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 16]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+   so that the control information received on a classical channel can
+   be applied to the qubits managed by the quantum data plane.
 
 5.3.  Abstract model of the network
 
@@ -942,9 +945,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
       have a quantum data plane.  A non-quantum node is any device that
       can handle classical network traffic.
 
-   Additionally, we need to identify two kinds of links that will be
-   used in a quantum network:
-
 
 
 
@@ -953,6 +953,9 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 17]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+   Additionally, we need to identify two kinds of links that will be
+   used in a quantum network:
 
    o  Quantum links - A quantum link is a link which can be used to
       generate an entangled pair between two directly connected quantum
@@ -999,9 +1002,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    entangled over individual links, performing entanglement swaps, and
    further signalling to transmit the swap outcomes and other control
    information.  Since none of the entangled pairs carry any user data,
-   some of these operations can be performed before the request is
-   received in anticipation of the demand.
-
 
 
 
@@ -1009,6 +1009,9 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 18]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+   some of these operations can be performed before the request is
+   received in anticipation of the demand.
 
    The entangled pair is delivered to the application once it is ready,
    together with the relevant pair identifier.  However, being ready
@@ -1052,12 +1055,9 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    these boundaries will be handled is also an open question and thus
    beyond the scope of this memo.
 
-5.5.  Physical constraints
 
-   The model above has effectively abstracted away the particulars of
-   the hardware implementation.  However, certain physical constraints
-   need to be considered in order to build a practical network.  Some of
-   these are fundamental constraints and no matter how much the
+
+
 
 
 
@@ -1066,6 +1066,12 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 19]
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+5.5.  Physical constraints
+
+   The model above has effectively abstracted away the particulars of
+   the hardware implementation.  However, certain physical constraints
+   need to be considered in order to build a practical network.  Some of
+   these are fundamental constraints and no matter how much the
    technology improves, they will always need to be addressed.  Others
    are artefacts of the early stages of a new technology.  Here, we
    consider a highly abstract scenario and refer to [5] for pointers to
@@ -1108,12 +1114,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    called communication qubits.  Once a Bell pair has been generated
    using a communication qubit, its state can be transferred into
    memory.  This may impose additional limitations on the network.  In
-   particular if a given node has only one communication qubit it cannot
-   simultaneously generate Bell Pairs over two links.  It must generate
-   entanglement over the links one at a time.
-
-
-
 
 
 
@@ -1121,6 +1121,10 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 20]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+   particular if a given node has only one communication qubit it cannot
+   simultaneously generate Bell Pairs over two links.  It must generate
+   entanglement over the links one at a time.
 
 5.5.4.  Homogeneity
 
@@ -1166,10 +1170,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
        This goal seems trivially obvious, but makes a subtle, but
        important point which highlights a key difference between quantum
-       and classical networks.  Ultimately, quantum data transmission is
-       not the goal of a quantum network - it is only one possible
-       component of more advanced quantum application protocols.  Whilst
-       transmission certainly could be used as a building block for all
 
 
 
@@ -1178,6 +1178,10 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 21]
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+       and classical networks.  Ultimately, quantum data transmission is
+       not the goal of a quantum network - it is only one possible
+       component of more advanced quantum application protocols.  Whilst
+       transmission certainly could be used as a building block for all
        quantum applications, it is certainly not the most basic one
        possible.  For example, QKD, the most well known quantum
        application protocol only relies on the stronger than classical
@@ -1221,11 +1225,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        repeater hardware and they all have their advantages and
        disadvantages.  Some may offer higher Bell pair generation rates
        on individual links at the cost of more difficult entanglement
-       swap operations.  Other platforms may be good all around, but are
-       more difficult to build.
 
-       Whilst conceptually they are all capable of the same tasks the
-       optimal network configuration will likely leverage the advantages
 
 
 
@@ -1234,6 +1234,11 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 22]
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+       swap operations.  Other platforms may be good all around, but are
+       more difficult to build.
+
+       Whilst conceptually they are all capable of the same tasks the
+       optimal network configuration will likely leverage the advantages
        of multiple platforms to optimise the provided service.
        Therefore, it is an explicit goal to incorporate varied hardware
        support from the beginning.
@@ -1276,11 +1281,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        than demanding that the network deliver secure entanglement in
        the first place.
 
-       Nevertheless, control protocols themselves should be security
-       aware in order to protect the operation of the network itself and
-       limit disruption.  This will primarily involve securing the
-       classical control and management traffic by means of
-       authentication and possibly encryption.
 
 
 
@@ -1289,6 +1289,12 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 23]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+       Nevertheless, control protocols themselves should be security
+       aware in order to protect the operation of the network itself and
+       limit disruption.  This will primarily involve securing the
+       classical control and management traffic by means of
+       authentication and possibly encryption.
 
    6.  Make them easy to manage and monitor
 
@@ -1331,13 +1337,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
    2.  Bell Pairs are indistinguishable
 
-       Any two Bell Pairs between the same two nodes are
-       indistinguishable for the purposes of an application provided
-       they both satisfy its required fidelity threshold.  This point is
-       crucial in enabling the reuse of resources of a network and for
-       the purposes of provisioning resources to meet application
-       demand.  However, the qubits that make up the pair themselves are
-       not indistinguishable and the two nodes operating on a pair must
+
 
 
 
@@ -1346,6 +1346,13 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 24]
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+       Any two Bell Pairs between the same two nodes are
+       indistinguishable for the purposes of an application provided
+       they both satisfy its required fidelity threshold.  This point is
+       crucial in enabling the reuse of resources of a network and for
+       the purposes of provisioning resources to meet application
+       demand.  However, the qubits that make up the pair themselves are
+       not indistinguishable and the two nodes operating on a pair must
        coordinate to make sure they are operating on qubits that belong
        to the same Bell Pair.
 
@@ -1388,13 +1395,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    communication.  However, as this is an informational memo it does not
    propose any concrete mechanisms to achieve these goals.
 
-   In summary:
-
-   As long as the underlying implementation corresponds to (or
-   sufficiently approximates) theoretical models of quantum
-   cryptography, quantum cryptographic protocols do not need the network
-   to provide any guarantees about the authenticity, confidentiality, or
-
 
 
 Kozlowski, et al.       Expires September 6, 2020              [Page 25]
@@ -1402,6 +1402,12 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 25]
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+   In summary:
+
+   As long as the underlying implementation corresponds to (or
+   sufficiently approximates) theoretical models of quantum
+   cryptography, quantum cryptographic protocols do not need the network
+   to provide any guarantees about the authenticity, confidentiality, or
    integrity of the transmitted qubits or the generated entanglement.
    Instead, applications such as QKD establish such guarantees using the
    classical network in conjunction with he quantum one.  This is much
@@ -1443,12 +1449,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
               it hasn't)", Nature 554, 289-292, 2018,
               <https://www.nature.com/articles/d41586-018-01835-3>.
 
-   [5]        Wehner, S., Elkouss, D., and R. Hanson, "Quantum internet:
-              A vision for the road ahead", Science 362, 6412, 2018,
-              <http://science.sciencemag.org/content/362/6412/
-              eaam9288.full>.
-
-
 
 
 
@@ -1457,6 +1457,11 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 26]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+   [5]        Wehner, S., Elkouss, D., and R. Hanson, "Quantum internet:
+              A vision for the road ahead", Science 362, 6412, 2018,
+              <http://science.sciencemag.org/content/362/6412/
+              eaam9288.full>.
 
    [6]        Aspect, A., Grangier, P., and G. Roger, "Experimental
               Tests of Realistic Local Theories via Bell's Theorem",
@@ -1498,11 +1503,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
               Teleportation for the Quantum Internet",   , 2019,
               <https://arxiv.org/abs/1907.06197>.
 
-Authors' Addresses
-
-
-
-
 
 
 
@@ -1513,6 +1513,8 @@ Kozlowski, et al.       Expires September 6, 2020              [Page 27]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
+
+Authors' Addresses
 
    Wojciech Kozlowski
    QuTech
@@ -1557,8 +1559,6 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    Italy
 
    Email: angelasara.cacciapuoti@unina.it
-
-
 
 
 

--- a/draft-irtf-qirg-principles-03.txt
+++ b/draft-irtf-qirg-principles-03.txt
@@ -820,9 +820,9 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        Meanwhile, quantum networks of direct transmission are "routing
        and forwarding" networks.  Such quantum networks can carry
        arbitrary states hop by hop, therefore they are also "store and
-       forward" networks.  Hence direct transmission quantum network
-       could be more similar to classical networks in networking
-       algorithms.
+       forward" networks.  Hence this later generation of quantum
+       networks could have more in common with classical networks than
+       the first quantum networks in networking algorithms.
 
    3.  An entangled pair is only useful if the locations of both qubits
        are known.

--- a/draft-irtf-qirg-principles-03.txt
+++ b/draft-irtf-qirg-principles-03.txt
@@ -5,14 +5,16 @@
 Quantum Internet Research Group                             W. Kozlowski
 Internet-Draft                                                 S. Wehner
 Intended status: Informational                                    QuTech
-Expires: August 29, 2020                                    R. Van Meter
+Expires: September 4, 2020                                  R. Van Meter
                                                          Keio University
                                                               B. Rijsman
                                                               Individual
                                                        A. S. Cacciapuoti
                                                               M. Caleffi
                                         University of Naples Federico II
-                                                       February 26, 2019
+                                                             S. Nagayama
+                                                           Mercari, Inc.
+                                                           March 3, 2019
 
 
             Architectural Principles for a Quantum Internet
@@ -47,15 +49,13 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 29, 2020.
+   This Internet-Draft will expire on September 4, 2020.
 
 
 
-
-
-Kozlowski, et al.        Expires August 29, 2020                [Page 1]
+Kozlowski, et al.       Expires September 4, 2020               [Page 1]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 Copyright Notice
@@ -95,33 +95,33 @@ Table of Contents
        4.5.4.  Delivery  . . . . . . . . . . . . . . . . . . . . . .  14
    5.  Architecture of a quantum internet  . . . . . . . . . . . . .  14
      5.1.  New challenges  . . . . . . . . . . . . . . . . . . . . .  14
-     5.2.  Classical communication . . . . . . . . . . . . . . . . .  15
-     5.3.  Abstract model of the network . . . . . . . . . . . . . .  16
-       5.3.1.  Elements of a quantum network . . . . . . . . . . . .  16
-       5.3.2.  Putting it all together . . . . . . . . . . . . . . .  17
-     5.4.  Network boundaries  . . . . . . . . . . . . . . . . . . .  18
-       5.4.1.  Boundaries between different physical architectures .  18
-       5.4.2.  Boundaries between different administrative regions .  18
+     5.2.  Classical communication . . . . . . . . . . . . . . . . .  16
+     5.3.  Abstract model of the network . . . . . . . . . . . . . .  17
+       5.3.1.  Elements of a quantum network . . . . . . . . . . . .  17
+       5.3.2.  Putting it all together . . . . . . . . . . . . . . .  18
+     5.4.  Network boundaries  . . . . . . . . . . . . . . . . . . .  19
+       5.4.1.  Boundaries between different physical architectures .  19
+       5.4.2.  Boundaries between different administrative regions .  19
      5.5.  Physical constraints  . . . . . . . . . . . . . . . . . .  19
-       5.5.1.  Memory lifetimes  . . . . . . . . . . . . . . . . . .  19
-       5.5.2.  Rates . . . . . . . . . . . . . . . . . . . . . . . .  19
+       5.5.1.  Memory lifetimes  . . . . . . . . . . . . . . . . . .  20
+       5.5.2.  Rates . . . . . . . . . . . . . . . . . . . . . . . .  20
        5.5.3.  Communication qubits  . . . . . . . . . . . . . . . .  20
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 2]
+Kozlowski, et al.       Expires September 4, 2020               [Page 2]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
-       5.5.4.  Homogeneity . . . . . . . . . . . . . . . . . . . . .  20
-   6.  Architectural principles  . . . . . . . . . . . . . . . . . .  20
-     6.1.  Goals of a quantum internet . . . . . . . . . . . . . . .  20
-     6.2.  The principles of a quantum internet  . . . . . . . . . .  23
+       5.5.4.  Homogeneity . . . . . . . . . . . . . . . . . . . . .  21
+   6.  Architectural principles  . . . . . . . . . . . . . . . . . .  21
+     6.1.  Goals of a quantum internet . . . . . . . . . . . . . . .  21
+     6.2.  The principles of a quantum internet  . . . . . . . . . .  24
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
-   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
-   10. Informative References  . . . . . . . . . . . . . . . . . . .  25
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
+   10. Informative References  . . . . . . . . . . . . . . . . . . .  26
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  27
 
 1.  Introduction
@@ -165,9 +165,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 3]
+Kozlowski, et al.       Expires September 4, 2020               [Page 3]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 2.  Quantum information
@@ -221,9 +221,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 4]
+Kozlowski, et al.       Expires September 4, 2020               [Page 4]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 2.2.  Multiple qubits
@@ -277,9 +277,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 5]
+Kozlowski, et al.       Expires September 4, 2020               [Page 5]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
    What is so interesting about this two-qubit gate operation?  The
@@ -333,9 +333,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 6]
+Kozlowski, et al.       Expires September 4, 2020               [Page 6]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
    Entanglement has two very special features from which one can derive
@@ -389,9 +389,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 7]
+Kozlowski, et al.       Expires September 4, 2020               [Page 7]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 4.  Achieving quantum connectivity
@@ -445,9 +445,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 8]
+Kozlowski, et al.       Expires September 4, 2020               [Page 8]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 4.1.3.  Fidelity
@@ -501,9 +501,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020                [Page 9]
+Kozlowski, et al.       Expires September 4, 2020               [Page 9]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 4.3.  Bell pairs
@@ -557,9 +557,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020               [Page 10]
+Kozlowski, et al.       Expires September 4, 2020              [Page 10]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
    Bell pair's entanglement turning the source and destination qubits
@@ -613,9 +613,9 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020               [Page 11]
+Kozlowski, et al.       Expires September 4, 2020              [Page 11]
 
-Internet-Draft      Principles for a Quantum Internet      February 2019
+Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
       entanglement from the flying qubits to the matter qubits.  In this
@@ -644,6 +644,11 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    other schemes the nodes retain greater control over the entangled
    pair generation.
 
+   Note that photons flies in direction, however, residual entanglements
+   are undirected resources.  Therefore we can choice any type of link
+   generation and any direction of photon transmission, depending on
+   policy, or for optimization.
+
 4.5.2.  Entanglement swapping
 
    The problem with generating entangled pairs directly across a link is
@@ -660,19 +665,20 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    This process is known as entanglement swapping.  Pictorially it can
    be represented as follows:
 
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 12]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
    +---------+      +---------+      +---------+
    |    A    |      |    B    |      |    C    |
    |         |------|         |------|         |
    |      X1~~~~~~~~~~X2   Y1~~~~~~~~~~Y2      |
    +---------+      +---------+      +---------+
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 12]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
 
    where X1 and X2 are the qubits of the entangled pair X and Y1 and Y2
    are the qubits of entangled pair Y.  The entanglement is denoted with
@@ -716,20 +722,20 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    pairs through a process called distillation (sometimes also referred
    to as purification).
 
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 13]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
    To distil a quantum state, a second (and sometimes third) quantum
    state is used as a "test tool" to test a proposition about the first
    state, e.g., "the parity of the first state is even."  When the test
    succeeds, confidence in the state is improved, and thus the fidelity
    is improved.  The test tool states are destroyed in the process, so
    resource demands increase substantially when distillation is used.
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 13]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    When the test fails, the tested state must also be discarded.
    Distillation makes low demands on fidelity and resources, but
    distributed protocols incur round-trip delays [11].
@@ -773,19 +779,52 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        information via separate classical channels which the repeaters
        will have to correlate with the qubits stored in their memory.
 
-   2.  An entangled pair is only useful if the locations of both qubits
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 14]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
+   2.  The first quantum networks may not be "routing and forwarding"
+       networks.
+
+       Quantum links provide Bell pairs that are undirected network
+       resources, in contrast to directed links of classical networks.
+       This phenomenological distinction requires architectural
+       differences between quantum networks and classical networks.
+
+       Classical networks have routing and forwarding; routing decides
+       the way to go and forwarding executes actual data transfer,
+       obeying the decision.  Quantum networks execute routing in a
+       control plane and execute entanglement swapping instead of
+       forwarding in a data plane.  Such quantum networks are "routing
+       and swapping" networks.  In "routing and swapping" networks, we
+       do not need to care the order of generating link Bell pairs,
+       since Bell pairs are undirected resources.  This distinction
+       makes control algorithms and optimization of quantum networks
+       different from classical ones.
+
+       Technically, entanglement swapping first generates a large
+       entangled state among four qubits over three nodes and then
+       measures two qubits in the middle node to leave a Bell pair
+       between two distant nodes.  In this sense, "routing and swapping"
+       networks also belong to "routing and measuring" networks.
+       Entanglement swapping is a specific algorithm for a set of Bell
+       pairs.  More algorithms to build a quantum network from Bell
+       pairs.  have been proposed.  "Routing and measuring" is a broader
+       category and more types of quantum networks belong to it.
+
+       Meanwhile, quantum networks of direct transmission are "routing
+       and forwarding" networks.  Such quantum networks can carry
+       arbitrary states hop by hop, therefore they are also "store and
+       forward" networks.
+
+   3.  An entangled pair is only useful if the locations of both qubits
        are known.
 
        A classical network packet logically exists only at one location
        at any point in time.  If a packet is modified in some way,
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 14]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
        headers or payload, this information does not need to be conveyed
        to anybody else in the network.  The packet can be simply
        forwarded as before.
@@ -795,6 +834,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        one of the qubits change the mutual state of the pair.  Since the
        owner of a particular qubit cannot just read out its state, it
        must coordinate all its actions with the owner of the pair's
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 15]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
        other qubit.  Therefore, the owner of any qubit that is part of
        an entangled pair must know the location of its counterpart.
        Location, in this context, need not be the explicit spatial
@@ -802,7 +849,7 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        between the pair owners, and an association between the pair ID
        and the individual qubits is sufficient.
 
-   3.  Generating entanglement requires temporary state.
+   4.  Generating entanglement requires temporary state.
 
        Packet forwarding in a classical network is largely a stateless
        operation.  When a packet is received, the router looks up its
@@ -834,20 +881,22 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
    Classical communication is a crucial building block of any quantum
    network.  All nodes in a quantum network are assumed to have
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 15]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    classical connectivity with each other (within typical administrative
    domain limts).  Therefore, quantum routers will need to manage two
    data planes in parallel, a classical one and a quantum one.
    Additionally, it must be able to correlate information between them
    so that the control information received on a classical channel can
    be applied to the qubits managed by the quantum data plane.
+
+
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 16]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
 5.3.  Abstract model of the network
 
@@ -889,21 +938,21 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
       memory as certain quantum applications can be realised by having
       the end-node measure its qubit as soon as it is received.
 
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 16]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    o  Non-quantum nodes - Not all nodes in a quantum network need to
       have a quantum data plane.  A non-quantum node is any device that
       can handle classical network traffic.
 
    Additionally, we need to identify two kinds of links that will be
    used in a quantum network:
+
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 17]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
    o  Quantum links - A quantum link is a link which can be used to
       generate an entangled pair between two directly connected quantum
@@ -945,15 +994,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    and signalling protocols, but the details of how this is achieved are
    an active research question and thus beyond the scope of this memo.
 
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 17]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    During or after the control information is distributed the network
    performs the necessary quantum operations such as generating
    entangled over individual links, performing entanglement swaps, and
@@ -961,6 +1001,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    information.  Since none of the entangled pairs carry any user data,
    some of these operations can be performed before the request is
    received in anticipation of the demand.
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 18]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
    The entangled pair is delivered to the application once it is ready,
    together with the relevant pair identifier.  However, being ready
@@ -1001,15 +1049,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    Just like in classical networks, multiple quantum networks will
    connect into a global quantum internet.  This necessarily implies the
    existence of borders between different administrative regions.  How
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 18]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    these boundaries will be handled is also an open question and thus
    beyond the scope of this memo.
 
@@ -1019,6 +1058,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    the hardware implementation.  However, certain physical constraints
    need to be considered in order to build a practical network.  Some of
    these are fundamental constraints and no matter how much the
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 19]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
    technology improves, they will always need to be addressed.  Others
    are artefacts of the early stages of a new technology.  Here, we
    consider a highly abstract scenario and refer to [5] for pointers to
@@ -1054,18 +1101,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    lifetimes this leads to very tight timing windows to build up
    network-wide connectivity.
 
-
-
-
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 19]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
 5.5.3.  Communication qubits
 
    Most physical architectures capable of storing qubits are only able
@@ -1076,6 +1111,16 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    particular if a given node has only one communication qubit it cannot
    simultaneously generate Bell Pairs over two links.  It must generate
    entanglement over the links one at a time.
+
+
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 20]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
 5.5.4.  Homogeneity
 
@@ -1114,14 +1159,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    sort of goals should drive a quantum network architecture?  The
    following list has been inspired by the history of the classical
    Internet, but it will inevitably evolve with time and the needs of
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 20]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    its users.  The goals are listed in order of priority which in itself
    may also evolve as the community learns more about the technology.
 
@@ -1133,6 +1170,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        not the goal of a quantum network - it is only one possible
        component of more advanced quantum application protocols.  Whilst
        transmission certainly could be used as a building block for all
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 21]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
        quantum applications, it is certainly not the most basic one
        possible.  For example, QKD, the most well known quantum
        application protocol only relies on the stronger than classical
@@ -1170,14 +1215,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        they are not based on quantum repeaters and thus will not be able
        to easily transition more sophisticated applications.
 
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 21]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    3.  Support hardware heterogeneity
 
        There are multiple proposals for realising practical quantum
@@ -1189,6 +1226,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
        Whilst conceptually they are all capable of the same tasks the
        optimal network configuration will likely leverage the advantages
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 22]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
        of multiple platforms to optimise the provided service.
        Therefore, it is an explicit goal to incorporate varied hardware
        support from the beginning.
@@ -1226,14 +1271,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        need the network to provide any guarantees about the
        authenticity, confidentiality, or integrity of the transmitted
        qubits or the generated entanglement.  Instead, applications,
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 22]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
        such as QKD, establish such guarantees using the classical
        network in conjunction with he quantum one.  This is much easier
        than demanding that the network deliver secure entanglement in
@@ -1244,6 +1281,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        limit disruption.  This will primarily involve securing the
        classical control and management traffic by means of
        authentication and possibly encryption.
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 23]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
    6.  Make them easy to manage and monitor
 
@@ -1281,15 +1326,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        distribution of entanglement between the nodes in a network.
        This point additionally specifies that the entanglement is
        primarily distributed in the form of the entangled Bell Pair
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 23]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
        states which should be used as a building block in providing
        other services, including more complex entangled states.
 
@@ -1302,6 +1338,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        the purposes of provisioning resources to meet application
        demand.  However, the qubits that make up the pair themselves are
        not indistinguishable and the two nodes operating on a pair must
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 24]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
        coordinate to make sure they are operating on qubits that belong
        to the same Bell Pair.
 
@@ -1334,18 +1378,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
        waiting queue at some node could be enough for the Bell Pairs to
        decohere.
 
-
-
-
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 24]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
 7.  Security Considerations
 
    Even though no user data enters a quantum network security is listed
@@ -1362,6 +1394,14 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    sufficiently approximates) theoretical models of quantum
    cryptography, quantum cryptographic protocols do not need the network
    to provide any guarantees about the authenticity, confidentiality, or
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 25]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
    integrity of the transmitted qubits or the generated entanglement.
    Instead, applications such as QKD establish such guarantees using the
    classical network in conjunction with he quantum one.  This is much
@@ -1394,14 +1434,6 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
               of Computing , 2002,
               <https://arxiv.org/abs/quant-ph/0206138>.
 
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 25]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    [3]        Giovanetti, V., Lloyd, S., and L. Maccone, "Quantum-
               enhanced measurements: beating the standard quantum
               limit", Science 306(5700), 1330-1336, 2004,
@@ -1415,6 +1447,16 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
               A vision for the road ahead", Science 362, 6412, 2018,
               <http://science.sciencemag.org/content/362/6412/
               eaam9288.full>.
+
+
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 26]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
    [6]        Aspect, A., Grangier, P., and G. Roger, "Experimental
               Tests of Realistic Local Theories via Bell's Theorem",
@@ -1451,19 +1493,26 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
               Quantum Communication", Phys. Rev. Lett. Vol. 81, Num. 26,
               1998, <https://arxiv.org/abs/quant-ph/9803056>.
 
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 26]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    [13]       Cacciapuoti, A., Caleffi, M., Van Meter, R., and L. Hanzo,
               "When Entanglement meets Classical Communications: Quantum
               Teleportation for the Quantum Internet",   , 2019,
               <https://arxiv.org/abs/1907.06197>.
 
 Authors' Addresses
+
+
+
+
+
+
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 27]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
 
    Wojciech Kozlowski
    QuTech
@@ -1500,20 +1549,6 @@ Authors' Addresses
    Email: brunorijsman@gmail.com
 
 
-
-
-
-
-
-
-
-
-
-Kozlowski, et al.        Expires August 29, 2020               [Page 27]
-
-Internet-Draft      Principles for a Quantum Internet      February 2019
-
-
    Angela Sara Cacciapuoti
    University of Naples Federico II
    Department of Electrical Engineering and Information Technologies
@@ -1524,12 +1559,33 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
    Email: angelasara.cacciapuoti@unina.it
 
 
+
+
+
+
+
+
+Kozlowski, et al.       Expires September 4, 2020              [Page 28]
+
+Internet-Draft      Principles for a Quantum Internet         March 2019
+
+
    Marcello Caleffi
    University of Naples Federico II
    Department of Electrical Engineering and Information Technologies
    Claudio 21
    Naples  80125
    Italy
+
+   Email: marcello.caleffi@unina.it
+
+
+   Shota Nagayama
+   Mercari, Inc.
+   Roppongi Hills Mori Tower 18F
+   6-10-1 Roppongi, Minato-ku
+   Tokyo  106-6118
+   Japan
 
    Email: marcello.caleffi@unina.it
 
@@ -1565,4 +1621,4 @@ Internet-Draft      Principles for a Quantum Internet      February 2019
 
 
 
-Kozlowski, et al.        Expires August 29, 2020               [Page 28]
+Kozlowski, et al.       Expires September 4, 2020              [Page 29]

--- a/draft-irtf-qirg-principles-03.txt
+++ b/draft-irtf-qirg-principles-03.txt
@@ -644,10 +644,10 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    other schemes the nodes retain greater control over the entangled
    pair generation.
 
-   Note that photons flies in a direction, however, residual
-   entanglements are undirected resources.  Therefore we can choice any
-   type of link generation and any direction of photon transmission,
-   depending on policy, or for optimization.
+   Note that photons fly in a direction, however, residual entanglements
+   are undirected resources.  Therefore we can choice any type of link
+   generation and any direction of photon transmission, depending on
+   policy, or for optimization.
 
 4.5.2.  Entanglement swapping
 
@@ -821,7 +821,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        and forwarding" networks.  Such quantum networks can carry
        arbitrary states hop by hop, therefore they are also "store and
        forward" networks.  Hence this later generation of quantum
-       networks could have more in common with classical networks than
+       networks would have more in common with classical networks than
        the first quantum networks in networking algorithms.
 
    3.  An entangled pair is only useful if the locations of both qubits

--- a/draft-irtf-qirg-principles-03.txt
+++ b/draft-irtf-qirg-principles-03.txt
@@ -5,7 +5,7 @@
 Quantum Internet Research Group                             W. Kozlowski
 Internet-Draft                                                 S. Wehner
 Intended status: Informational                                    QuTech
-Expires: September 4, 2020                                  R. Van Meter
+Expires: September 6, 2020                                  R. Van Meter
                                                          Keio University
                                                               B. Rijsman
                                                               Individual
@@ -14,7 +14,7 @@ Expires: September 4, 2020                                  R. Van Meter
                                         University of Naples Federico II
                                                              S. Nagayama
                                                            Mercari, Inc.
-                                                           March 3, 2019
+                                                           March 5, 2019
 
 
             Architectural Principles for a Quantum Internet
@@ -49,11 +49,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 4, 2020.
+   This Internet-Draft will expire on September 6, 2020.
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 1]
+Kozlowski, et al.       Expires September 6, 2020               [Page 1]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 2]
+Kozlowski, et al.       Expires September 6, 2020               [Page 2]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -165,7 +165,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 3]
+Kozlowski, et al.       Expires September 6, 2020               [Page 3]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -221,7 +221,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 4]
+Kozlowski, et al.       Expires September 6, 2020               [Page 4]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -277,7 +277,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 5]
+Kozlowski, et al.       Expires September 6, 2020               [Page 5]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -333,7 +333,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 6]
+Kozlowski, et al.       Expires September 6, 2020               [Page 6]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -389,7 +389,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 7]
+Kozlowski, et al.       Expires September 6, 2020               [Page 7]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -445,7 +445,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 8]
+Kozlowski, et al.       Expires September 6, 2020               [Page 8]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -501,7 +501,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020               [Page 9]
+Kozlowski, et al.       Expires September 6, 2020               [Page 9]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -557,7 +557,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 10]
+Kozlowski, et al.       Expires September 6, 2020              [Page 10]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -613,7 +613,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 11]
+Kozlowski, et al.       Expires September 6, 2020              [Page 11]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -644,10 +644,10 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
    other schemes the nodes retain greater control over the entangled
    pair generation.
 
-   Note that photons flies in direction, however, residual entanglements
-   are undirected resources.  Therefore we can choice any type of link
-   generation and any direction of photon transmission, depending on
-   policy, or for optimization.
+   Note that photons flies in a direction, however, residual
+   entanglements are undirected resources.  Therefore we can choice any
+   type of link generation and any direction of photon transmission,
+   depending on policy, or for optimization.
 
 4.5.2.  Entanglement swapping
 
@@ -669,7 +669,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 12]
+Kozlowski, et al.       Expires September 6, 2020              [Page 12]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -725,7 +725,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 13]
+Kozlowski, et al.       Expires September 6, 2020              [Page 13]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -781,7 +781,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 14]
+Kozlowski, et al.       Expires September 6, 2020              [Page 14]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -791,7 +791,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
        Quantum links provide Bell pairs that are undirected network
        resources, in contrast to directed links of classical networks.
-       This phenomenological distinction requires architectural
+       This phenomenological distinction should result in architectural
        differences between quantum networks and classical networks.
 
        Classical networks have routing and forwarding; routing decides
@@ -803,7 +803,8 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        do not need to care the order of generating link Bell pairs,
        since Bell pairs are undirected resources.  This distinction
        makes control algorithms and optimization of quantum networks
-       different from classical ones.
+       different from classical ones.  Additionally, "routing and
+       swapping" quantum networks are not "store and forward" networks.
 
        Technically, entanglement swapping first generates a large
        entangled state among four qubits over three nodes and then
@@ -812,13 +813,14 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        networks also belong to "routing and measuring" networks.
        Entanglement swapping is a specific algorithm for a set of Bell
        pairs.  More algorithms to build a quantum network from Bell
-       pairs.  have been proposed.  "Routing and measuring" is a broader
-       category and more types of quantum networks belong to it.
+       pairs have been proposed.  "Routing and measuring" is a broader
+       category and more types of quantum networks should belong to it.
 
        Meanwhile, quantum networks of direct transmission are "routing
        and forwarding" networks.  Such quantum networks can carry
-       arbitrary states hop by hop, therefore they are also "store and
-       forward" networks.
+       arbitrary states hop by hop.  Therefore they are also "store and
+       forward" networks, in contrast to "routing and swapping" quantum
+       networks.
 
    3.  An entangled pair is only useful if the locations of both qubits
        are known.
@@ -832,16 +834,16 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
        In contrast, entanglement is a phenomenon in which two or more
        qubits exist in a physically distributed state.  Operations on
        one of the qubits change the mutual state of the pair.  Since the
-       owner of a particular qubit cannot just read out its state, it
-       must coordinate all its actions with the owner of the pair's
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 15]
+Kozlowski, et al.       Expires September 6, 2020              [Page 15]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
+       owner of a particular qubit cannot just read out its state, it
+       must coordinate all its actions with the owner of the pair's
        other qubit.  Therefore, the owner of any qubit that is part of
        an entangled pair must know the location of its counterpart.
        Location, in this context, need not be the explicit spatial
@@ -891,9 +893,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-
-
-Kozlowski, et al.       Expires September 4, 2020              [Page 16]
+Kozlowski, et al.       Expires September 6, 2020              [Page 16]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -949,7 +949,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 17]
+Kozlowski, et al.       Expires September 6, 2020              [Page 17]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1005,7 +1005,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 18]
+Kozlowski, et al.       Expires September 6, 2020              [Page 18]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1061,7 +1061,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 19]
+Kozlowski, et al.       Expires September 6, 2020              [Page 19]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1117,7 +1117,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 20]
+Kozlowski, et al.       Expires September 6, 2020              [Page 20]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1173,7 +1173,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 21]
+Kozlowski, et al.       Expires September 6, 2020              [Page 21]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1229,7 +1229,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 22]
+Kozlowski, et al.       Expires September 6, 2020              [Page 22]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1285,7 +1285,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 23]
+Kozlowski, et al.       Expires September 6, 2020              [Page 23]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1341,7 +1341,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 24]
+Kozlowski, et al.       Expires September 6, 2020              [Page 24]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1397,7 +1397,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 25]
+Kozlowski, et al.       Expires September 6, 2020              [Page 25]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1453,7 +1453,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 26]
+Kozlowski, et al.       Expires September 6, 2020              [Page 26]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1509,7 +1509,7 @@ Authors' Addresses
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 27]
+Kozlowski, et al.       Expires September 6, 2020              [Page 27]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1565,7 +1565,7 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 28]
+Kozlowski, et al.       Expires September 6, 2020              [Page 28]
 
 Internet-Draft      Principles for a Quantum Internet         March 2019
 
@@ -1621,4 +1621,4 @@ Internet-Draft      Principles for a Quantum Internet         March 2019
 
 
 
-Kozlowski, et al.       Expires September 4, 2020              [Page 29]
+Kozlowski, et al.       Expires September 6, 2020              [Page 29]

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -676,11 +676,10 @@
          other schemes the nodes retain greater control over the entangled pair
          generation.</t>
 
-         <t> Note that photons fly in a direction, however, resulting
-         entanglements are undirected resources. Therefore we can choice
-         any type of link generation and any direction of photon transmission,
-         depending on policy, or for optimization.</t>
-
+         <t> Note that whilst photons are emitted in a particular direction the 
+         resulting entangled pair of qubits does not have a direction associated 
+         with it. Physically, there is no upstream or downstream end of the 
+         pair.</t>   
        </section>
 
        <section anchor="es" title="Entanglement swapping">

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -844,13 +844,6 @@
            optimization of quantum networks different from classical ones.
            <vspace blankLines="1" />
 
-           It is worth noting, that third generation <refer to generations section>
-           quantum repeaters will be able to transmit qubits directly
-           in a "store and forward" manner since they will be able to carry
-           arbitrary states hop by hop. Thus, the networking algorithms of the
-           later generations of quantum networks may end up having more in 
-           common with classical networks.</t>
-           
            <t>An entangled pair is only useful if the locations of both qubits
            are known.
            <vspace blankLines="1" />

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -944,11 +944,12 @@
            optimization of quantum networks different from classical ones.
            <vspace blankLines="1" />
 
-           Meanwhile, third generations of quantum networks of direct transmission
-           are "store and forward" networks, since such quantum networks can carry
-           arbitrary states hop by hop. Hence those later generations of
-           quantum networks would have more in common with classical networks
-           than the first quantum networks in networking algorithms.</t>
+           It is worth noting, that third generation <refer to generations section> 
+           quantum repeaters will be able to transmit qubits directly
+           in a "store and forward" manner since they will be able to carry
+           arbitrary states hop by hop. Thus, the networking algorithms of the
+           later generations of quantum networks may end up having more in 
+           common with classical networks.</t>
            
            <t>An entangled pair is only useful if the locations of both qubits
            are known.

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -857,8 +857,9 @@
            Meanwhile, quantum networks of direct transmission are "routing
            and forwarding" networks. Such quantum networks can carry
            arbitrary states hop by hop, therefore they are also
-           "store and forward" networks. Hence direct transmission quantum network
-           could be more similar to classical networks in networking algorithms.</t>
+           "store and forward" networks. Hence this later generation of
+           quantum networks could have more in common with classical networks
+           than the first quantum networks in networking algorithms.</t>
            
            <t>An entangled pair is only useful if the locations of both qubits
            are known.

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -160,6 +160,26 @@
      </address>
    </author>
 
+   <author fullname="Shota Nagayama" initials="S" surname="Nagayama">
+     <organization>Mercari, Inc.</organization>
+
+     <address>
+       <postal>
+         <street>Roppongi Hills Mori Tower 18F</street>
+         <street>6-10-1 Roppongi, Minato-ku</street>
+
+         <!-- Reorder these if your country does things differently -->
+         <code>106-6118</code>
+         <city>Tokyo</city>
+         <country>Japan</country>
+       </postal>
+
+       <email>marcello.caleffi@unina.it</email>
+
+       <!-- uri and facsimile elements may also be added -->
+     </address>
+   </author>
+
    <date year="2019" />
 
    <!-- If the month and year are both specified and are the current ones, xml2rfc will fill
@@ -656,6 +676,11 @@
          other schemes the nodes retain greater control over the entangled pair
          generation.</t>
 
+         <t> Note that photons flies in direction, however, residual
+         entanglements are undirected resources. Therefore we can choice
+         any type of link generation and any direction of photon transmission,
+         depending on policy, or for optimization.</t>
+
        </section>
 
        <section title="Entanglement swapping">
@@ -795,6 +820,43 @@
            information via separate classical channels which the repeaters will
            have to correlate with the qubits stored in their memory.</t>
 
+           <t> The first quantum networks may not be "routing and forwarding"
+           networks.
+           <vspace blankLines="1" />
+
+           Quantum links provide Bell pairs that are undirected network
+           resources, in contrast to directed links of classical networks.
+           This phenomenological distinction requires architectural differences
+           between quantum networks and classical networks.
+           <vspace blankLines="1" />
+
+           Classical networks have routing and forwarding; routing decides
+           the way to go and forwarding executes actual data transfer,
+           obeying the decision. Quantum networks execute routing in a control
+           plane and execute entanglement swapping instead of forwarding in
+           a data plane. Such quantum networks are "routing and swapping" networks.
+           In "routing and swapping" networks, we do not need to care
+           the order of generating link Bell pairs, since Bell pairs are
+           undirected resources. This distinction makes control algorithms and
+           optimization of quantum networks different from classical ones.
+           <vspace blankLines="1" />
+
+           Technically, entanglement swapping first generates a large entangled
+           state among four qubits over three nodes and then measures
+           two qubits in the middle node to leave a Bell pair between
+           two distant nodes. In this sense, "routing and swapping" networks
+           also belong to "routing and measuring" networks.
+           Entanglement swapping is a specific algorithm for a set of Bell pairs.
+           More algorithms to build a quantum network from Bell pairs.
+           have been proposed. "Routing and measuring" is a broader category
+           and more types of quantum networks belong to it.
+           <vspace blankLines="1" />
+
+           Meanwhile, quantum networks of direct transmission are "routing
+           and forwarding" networks. Such quantum networks can carry
+           arbitrary states hop by hop, therefore they are also
+           "store and forward" networks. </t>
+           
            <t>An entangled pair is only useful if the locations of both qubits
            are known.
            <vspace blankLines="1" />

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -936,7 +936,7 @@
            Classical networks receive data on one interface, store it on local buffers, 
            then forward the data to another appropriate interface.
            Quantum networks store Bell pairs and then
-           execute entanglement swapping instead of forwarding in a data plane.
+           execute entanglement swapping instead of forwarding in the data plane.
            Such quantum networks are "store and swap" networks.
            In "store and swap" networks, we do not need to care about
            the order of generating link Bell pairs since Bell pairs are

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -831,12 +831,12 @@
            <vspace blankLines="1" />
 
            Classical networks have routing and forwarding; routing decides
-           the way to go and forwarding executes actual data transfer,
-           obeying the decision. Quantum networks execute routing in a control
+           the way to go, and forwarding executes actual data transfer,
+           obeying the decision. Quantum networks perform routing in a control
            plane and execute entanglement swapping instead of forwarding in
            a data plane. Such quantum networks are "routing and swapping" networks.
-           In "routing and swapping" networks, we do not need to care
-           the order of generating link Bell pairs, since Bell pairs are
+           In "routing and swapping" networks, we do not need to care about
+           the order of generating link Bell pairs since Bell pairs are
            undirected resources. This distinction makes control algorithms and
            optimization of quantum networks different from classical ones.
            Additionally, "routing and swapping" quantum networks are not
@@ -850,15 +850,15 @@
            also belong to "routing and measuring" networks.
            Entanglement swapping is a specific algorithm for a set of Bell pairs.
            More algorithms to build a quantum network from Bell pairs
-           have been proposed. "Routing and measuring" is a broader category
-           and more types of quantum networks should belong to it.
+           have been proposed. "Routing and measuring" is a broader category,
+           and more types of quantum networks will be categorized into it.
            <vspace blankLines="1" />
 
            Meanwhile, quantum networks of direct transmission are "routing
            and forwarding" networks. Such quantum networks can carry
-           arbitrary states hop by hop. Therefore they are also
-           "store and forward" networks, in contrast to "routing and swapping"
-           quantum networks. </t>
+           arbitrary states hop by hop, therefore they are also
+           "store and forward" networks. Hence direct transmission quantum network
+           could be more similar to classical networks in networking algorithms.</t>
            
            <t>An entangled pair is only useful if the locations of both qubits
            are known.

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -531,7 +531,7 @@
        error correction to bring losses down to an acceptable level. Despite
        the no-cloning theorem and the inability to directly measure a quantum
        state, error-correcting mechanisms for quantum communication exist <xref
-       target="mural16"></xref>. However, quantum error correction makes very
+       target="mural14"></xref>. However, quantum error correction makes very
        high demands on both resources (physical qubits needed) and their
        initial fidelity. Implementation is very challenging and quantum error
        correction is not expected to be used until later generations of quantum
@@ -784,106 +784,6 @@
 
    </section>
 
-
-     <section anchor="gqn" title="Generations of Quantum Networks">
-
-       <t>Quantum networks are categorized into three generations
-       <xref target="mural16"></xref>. Those generations are defined by
-       the directions of signaling required in their distributed protocols
-       for loss tolerance and error tolerance. Such signalings
-       block the networking procedure; hence they affect the performance
-       of quantum networks, especially between non-adjacent nodes.
-       Table <xref target="gens"></xref> summalizes the generations.</t>
-
-
-       <texttable anchor="gens">
-         <ttcol align="center"></ttcol>
-         <ttcol align="center">First generation</ttcol>
-         <ttcol align="center">Second generation</ttcol>
-         <ttcol align="center">Third generation</ttcol>
-         
-         <c>Loss tolerance</c>
-         <c>Heralded entanglement generation (bi-directional classical signaling)</c>
-         <c>Heralded entanglement generation (bi-directional classical signaling)</c>
-         <c>Quantum Error Correction (uni-directional quantum signaling)</c>
-         
-         <c>Error tolerance</c>
-         <c>Entanglement distillation (bi-directional classical signaling)</c>
-         <c>Quantum Error Correction (uni-directional quantum signaling)</c>
-         <c>Quantum Error Correction (uni-directional quantum signaling)</c>
-       </texttable>
-
-       <t>
-       <list style="numbers">
-         <t>Quantum networks of the first generation generate end-to-end
-         physical Bell pairs. The procedure is:
-         <list style="numbers">
-           <t> Generate physical Bell pairs between adjacent nodes. Photon
-           losses are managed by the heralded entanglement generation schemes
-           shown in <xref target="elg"></xref>. Classical messages are sent in
-           the reverse way to tell which photons are received (hence
-           bi-directional signaling between adjacent nodes).</t>
-           <t> Entanglement distillation between adjacent nodes is executed
-           if the fidelity of Bell pairs is not enough. Claccical messages
-           are sent to tell the measurement outcomes to each other
-           (bi-directional signaling between adjacent nodes).</t>
-           <t> Entanglement swapping is executed. The measurement outcome
-           must be sent to a node that holds the other half Bell pair,
-           however, processing the measurement outcomes does not
-           block the networking procedure.</t>
-           <t> If the fidelity of Bell pairs between non-adjacent nodes
-           is estimated to be low, entanglement distillation is performed.
-           This entanglement distillation requires nodes to send measurement
-           outcomes to each other, which blocks the networking procedure
-           (bi-directional signaling between non-adjacent nodes).</t> 
-         </list>
-         </t>
-
-         <t>The second generations generate end-to-end logical Bell pairs
-         encoded on physical Bell pairs by quantum error correcting codes.
-         The procedure:
-         <list style="numbers">
-           <t> Generate physical Bell pairs between adjacent nodes. Photon
-           losses are managed by the heralded entanglement generation schemes
-           shown in <xref target="elg"></xref>. Classical messages are sent in
-           the reverse way to tell which photons are received (hence
-           bi-directional signaling between adjacent nodes).</t>
-           <t> Entanglement distillation between adjacent nodes is executed
-           if the fidelity of Bell pairs is not enough. Claccical messages
-           are sent to tell the measurement outcomes to each other
-           (bi-directional signaling between adjacent nodes).</t>
-           <t> Encode (|0> + |1>)/sqrt(2) x |0> = (|00> + |10>)/sqrt(2)
-           and |0> by a quantum  error correcting code in a set of adjacent
-           nodes respectively. Errors will be managed by this error correcting
-           code locally.</t>
-           <t> Execute teleportation-based transversal non-local CNOT gates 
-           to generate logical Bell pairs between adjacent nodes.</t>
-           <t> (Logicl) entanglement swapping is executed. The measurement
-           outcome must be sent to a node that holds the other half Bell pair,
-           however, processing the measurement outcomes does not
-           block the networking procedure.</t>
-         </list>
-         </t>
-         
-         <t>The third genereations are of direct transmission discussed in
-         <xref target="dt"></xref>, that forwards logical qubits hop by hop.
-         The procedure is:
-         <list style="numbers">
-           <t> Encode arbitrary quantum state on photons with a quantum
-           error correcting code.</t>
-           <t> Send the photons to an adjacent node. (uni-directional signaling
-           between adjacent nodes)</t>
-           <t> Execute error correction to restore lost photons and to
-           correct errors.</t>
-         </list>
-         </t>
-       </list>
-       </t>
-
-       <t>The later generation requires higher technologies. This document
-       concentrates the first generation of the quantum networks.</t>
-     </section>
-     
    <section title="Architecture of a quantum internet">
 
      <t>It is evident from the previous sections that the fundamental service
@@ -944,7 +844,7 @@
            optimization of quantum networks different from classical ones.
            <vspace blankLines="1" />
 
-           It is worth noting, that third generation <xref target="gqn"></xref>
+           It is worth noting, that third generation <refer to generations section>
            quantum repeaters will be able to transmit qubits directly
            in a "store and forward" manner since they will be able to carry
            arbitrary states hop by hop. Thus, the networking algorithms of the
@@ -1729,7 +1629,7 @@ CC - classical channel
        <seriesInfo name="Phys. Rev. Lett." value="47 (7): 460-463" />
      </reference>
 
-     <reference anchor="mural16" target="https://www.nature.com/articles/srep20463">
+     <reference anchor="mural14" target="https://arxiv.org/abs/1310.5291">
        <front>
          <title>Ultrafast and Fault-Tolerant Quantum Communication across Long
          Distances</title>

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -676,7 +676,7 @@
          other schemes the nodes retain greater control over the entangled pair
          generation.</t>
 
-         <t> Note that photons flies in direction, however, residual
+         <t> Note that photons flies in a direction, however, residual
          entanglements are undirected resources. Therefore we can choice
          any type of link generation and any direction of photon transmission,
          depending on policy, or for optimization.</t>
@@ -826,8 +826,8 @@
 
            Quantum links provide Bell pairs that are undirected network
            resources, in contrast to directed links of classical networks.
-           This phenomenological distinction requires architectural differences
-           between quantum networks and classical networks.
+           This phenomenological distinction should result in architectural
+           differences between quantum networks and classical networks.
            <vspace blankLines="1" />
 
            Classical networks have routing and forwarding; routing decides
@@ -839,6 +839,8 @@
            the order of generating link Bell pairs, since Bell pairs are
            undirected resources. This distinction makes control algorithms and
            optimization of quantum networks different from classical ones.
+           Additionally, "routing and swapping" quantum networks are not
+           "store and forward" networks.
            <vspace blankLines="1" />
 
            Technically, entanglement swapping first generates a large entangled
@@ -847,15 +849,16 @@
            two distant nodes. In this sense, "routing and swapping" networks
            also belong to "routing and measuring" networks.
            Entanglement swapping is a specific algorithm for a set of Bell pairs.
-           More algorithms to build a quantum network from Bell pairs.
+           More algorithms to build a quantum network from Bell pairs
            have been proposed. "Routing and measuring" is a broader category
-           and more types of quantum networks belong to it.
+           and more types of quantum networks should belong to it.
            <vspace blankLines="1" />
 
            Meanwhile, quantum networks of direct transmission are "routing
            and forwarding" networks. Such quantum networks can carry
-           arbitrary states hop by hop, therefore they are also
-           "store and forward" networks. </t>
+           arbitrary states hop by hop. Therefore they are also
+           "store and forward" networks, in contrast to "routing and swapping"
+           quantum networks. </t>
            
            <t>An entangled pair is only useful if the locations of both qubits
            are known.

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -174,7 +174,7 @@
          <country>Japan</country>
        </postal>
 
-       <email>marcello.caleffi@unina.it</email>
+       <email>shota.nagayama@mercari.com</email>
 
        <!-- uri and facsimile elements may also be added -->
      </address>
@@ -531,7 +531,7 @@
        error correction to bring losses down to an acceptable level. Despite
        the no-cloning theorem and the inability to directly measure a quantum
        state, error-correcting mechanisms for quantum communication exist <xref
-       target="mural14"></xref>. However, quantum error correction makes very
+       target="mural16"></xref>. However, quantum error correction makes very
        high demands on both resources (physical qubits needed) and their
        initial fidelity. Implementation is very challenging and quantum error
        correction is not expected to be used until later generations of quantum
@@ -785,10 +785,10 @@
    </section>
 
 
-     <section title="Generations of Quantum Networks">
+     <section anchor="gqn" title="Generations of Quantum Networks">
 
        <t>Quantum networks are categorized into three generations
-       <xref target="mural14"></xref>. Those generations are defined by
+       <xref target="mural16"></xref>. Those generations are defined by
        the directions of signaling required in their distributed protocols
        for loss tolerance and error tolerance. Such signalings
        block the networking procedure; hence they affect the performance
@@ -925,7 +925,7 @@
 
            As described in <xref target="elg"></xref>,
            Quantum links provide Bell pairs that are undirected network
-           resources, in contrast to directed links of classical networks.
+           resources, in contrast to directed frames of classical networks.
            This phenomenological distinction should result in architectural
            differences between quantum networks and classical networks;
            quantum networks put link Bell pairs together to an end-to-end
@@ -944,7 +944,7 @@
            optimization of quantum networks different from classical ones.
            <vspace blankLines="1" />
 
-           It is worth noting, that third generation <refer to generations section> 
+           It is worth noting, that third generation <xref target="gqn"></xref>
            quantum repeaters will be able to transmit qubits directly
            in a "store and forward" manner since they will be able to carry
            arbitrary states hop by hop. Thus, the networking algorithms of the
@@ -1729,7 +1729,7 @@ CC - classical channel
        <seriesInfo name="Phys. Rev. Lett." value="47 (7): 460-463" />
      </reference>
 
-     <reference anchor="mural14" target="https://arxiv.org/abs/1310.5291">
+     <reference anchor="mural16" target="https://www.nature.com/articles/srep20463">
        <front>
          <title>Ultrafast and Fault-Tolerant Quantum Communication across Long
          Distances</title>

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -676,7 +676,7 @@
          other schemes the nodes retain greater control over the entangled pair
          generation.</t>
 
-         <t> Note that photons flies in a direction, however, residual
+         <t> Note that photons fly in a direction, however, residual
          entanglements are undirected resources. Therefore we can choice
          any type of link generation and any direction of photon transmission,
          depending on policy, or for optimization.</t>
@@ -858,7 +858,7 @@
            and forwarding" networks. Such quantum networks can carry
            arbitrary states hop by hop, therefore they are also
            "store and forward" networks. Hence this later generation of
-           quantum networks could have more in common with classical networks
+           quantum networks would have more in common with classical networks
            than the first quantum networks in networking algorithms.</t>
            
            <t>An entangled pair is only useful if the locations of both qubits

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -935,7 +935,7 @@
 
            Classical networks receive data on one interface, store it on local buffers, 
            then forward the data to another appropriate interface.
-           Quantum networks store a couple of half Bell pairs, then
+           Quantum networks store Bell pairs and then
            execute entanglement swapping instead of forwarding in a data plane.
            Such quantum networks are "store and swap" networks.
            In "store and swap" networks, we do not need to care about

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -933,8 +933,8 @@
            to the other end hop by hop.
            <vspace blankLines="1" />
 
-           Classical networks store data coming from an interface, then forward
-           the data to another appropreate interface.
+           Classical networks receive data on one interface, store it on local buffers, 
+           then forward the data to another appropriate interface.
            Quantum networks store a couple of half Bell pairs, then
            execute entanglement swapping instead of forwarding in a data plane.
            Such quantum networks are "store and swap" networks.

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -523,7 +523,7 @@
 
      </section>
 
-     <section title="Direct transmission">
+     <section anchor="dt" title="Direct transmission">
 
        <t>Conceptually, the most straightforward way to distribute an entangled
        state is to simply transmit one of the qubits directly to the other end
@@ -616,7 +616,7 @@
        section we discuss, how these entangled pairs are generated in the first
        place, and how its two qubits are delivered to the end-points.</t>
 
-       <section title="Elementary link generation">
+       <section anchor="elg" title="Elementary link generation">
 
          <t>In a quantum network, entanglement is always first generated
          locally (at a node or an auxiliary element) followed by a movement of
@@ -676,14 +676,14 @@
          other schemes the nodes retain greater control over the entangled pair
          generation.</t>
 
-         <t> Note that photons fly in a direction, however, residual
+         <t> Note that photons fly in a direction, however, resulting
          entanglements are undirected resources. Therefore we can choice
          any type of link generation and any direction of photon transmission,
          depending on policy, or for optimization.</t>
 
        </section>
 
-       <section title="Entanglement swapping">
+       <section anchor="es" title="Entanglement swapping">
 
          <t>The problem with generating entangled pairs directly across a link
          is that its efficiency decreases with its length. Beyond a few 10s of
@@ -785,6 +785,106 @@
 
    </section>
 
+
+     <section title="Generations of Quantum Networks">
+
+       <t>Quantum networks are categorized into three generations
+       <xref target="mural14"></xref>. Those generations are defined by
+       the directions of signaling required in their distributed protocols
+       for loss tolerance and error tolerance. Such signalings
+       block the networking procedure; hence they affect the performance
+       of quantum networks, especially between non-adjacent nodes.
+       Table <xref target="gens"></xref> summalizes the generations.</t>
+
+
+       <texttable anchor="gens">
+         <ttcol align="center"></ttcol>
+         <ttcol align="center">First generation</ttcol>
+         <ttcol align="center">Second generation</ttcol>
+         <ttcol align="center">Third generation</ttcol>
+         
+         <c>Loss tolerance</c>
+         <c>Heralded entanglement generation (bi-directional classical signaling)</c>
+         <c>Heralded entanglement generation (bi-directional classical signaling)</c>
+         <c>Quantum Error Correction (uni-directional quantum signaling)</c>
+         
+         <c>Error tolerance</c>
+         <c>Entanglement distillation (bi-directional classical signaling)</c>
+         <c>Quantum Error Correction (uni-directional quantum signaling)</c>
+         <c>Quantum Error Correction (uni-directional quantum signaling)</c>
+       </texttable>
+
+       <t>
+       <list style="numbers">
+         <t>Quantum networks of the first generation generate end-to-end
+         physical Bell pairs. The procedure is:
+         <list style="numbers">
+           <t> Generate physical Bell pairs between adjacent nodes. Photon
+           losses are managed by the heralded entanglement generation schemes
+           shown in <xref target="elg"></xref>. Classical messages are sent in
+           the reverse way to tell which photons are received (hence
+           bi-directional signaling between adjacent nodes).</t>
+           <t> Entanglement distillation between adjacent nodes is executed
+           if the fidelity of Bell pairs is not enough. Claccical messages
+           are sent to tell the measurement outcomes to each other
+           (bi-directional signaling between adjacent nodes).</t>
+           <t> Entanglement swapping is executed. The measurement outcome
+           must be sent to a node that holds the other half Bell pair,
+           however, processing the measurement outcomes does not
+           block the networking procedure.</t>
+           <t> If the fidelity of Bell pairs between non-adjacent nodes
+           is estimated to be low, entanglement distillation is performed.
+           This entanglement distillation requires nodes to send measurement
+           outcomes to each other, which blocks the networking procedure
+           (bi-directional signaling between non-adjacent nodes).</t> 
+         </list>
+         </t>
+
+         <t>The second generations generate end-to-end logical Bell pairs
+         encoded on physical Bell pairs by quantum error correcting codes.
+         The procedure:
+         <list style="numbers">
+           <t> Generate physical Bell pairs between adjacent nodes. Photon
+           losses are managed by the heralded entanglement generation schemes
+           shown in <xref target="elg"></xref>. Classical messages are sent in
+           the reverse way to tell which photons are received (hence
+           bi-directional signaling between adjacent nodes).</t>
+           <t> Entanglement distillation between adjacent nodes is executed
+           if the fidelity of Bell pairs is not enough. Claccical messages
+           are sent to tell the measurement outcomes to each other
+           (bi-directional signaling between adjacent nodes).</t>
+           <t> Encode (|0> + |1>)/sqrt(2) x |0> = (|00> + |10>)/sqrt(2)
+           and |0> by a quantum  error correcting code in a set of adjacent
+           nodes respectively. Errors will be managed by this error correcting
+           code locally.</t>
+           <t> Execute teleportation-based transversal non-local CNOT gates 
+           to generate logical Bell pairs between adjacent nodes.</t>
+           <t> (Logicl) entanglement swapping is executed. The measurement
+           outcome must be sent to a node that holds the other half Bell pair,
+           however, processing the measurement outcomes does not
+           block the networking procedure.</t>
+         </list>
+         </t>
+         
+         <t>The third genereations are of direct transmission discussed in
+         <xref target="dt"></xref>, that forwards logical qubits hop by hop.
+         The procedure is:
+         <list style="numbers">
+           <t> Encode arbitrary quantum state on photons with a quantum
+           error correcting code.</t>
+           <t> Send the photons to an adjacent node. (uni-directional signaling
+           between adjacent nodes)</t>
+           <t> Execute error correction to restore lost photons and to
+           correct errors.</t>
+         </list>
+         </t>
+       </list>
+       </t>
+
+       <t>The later generation requires higher technologies. This document
+       concentrates the first generation of the quantum networks.</t>
+     </section>
+     
    <section title="Architecture of a quantum internet">
 
      <t>It is evident from the previous sections that the fundamental service
@@ -820,44 +920,34 @@
            information via separate classical channels which the repeaters will
            have to correlate with the qubits stored in their memory.</t>
 
-           <t> The first quantum networks may not be "routing and forwarding"
+           <t> First generations of quantum networks will not be store-and-forward
            networks.
            <vspace blankLines="1" />
 
+           As described in <xref target="elg"></xref>,
            Quantum links provide Bell pairs that are undirected network
            resources, in contrast to directed links of classical networks.
            This phenomenological distinction should result in architectural
-           differences between quantum networks and classical networks.
+           differences between quantum networks and classical networks;
+           quantum networks put link Bell pairs together to an end-to-end
+           Bell pair where classical networks deliver messages from an end
+           to the other end hop by hop.
            <vspace blankLines="1" />
 
-           Classical networks have routing and forwarding; routing decides
-           the way to go, and forwarding executes actual data transfer,
-           obeying the decision. Quantum networks perform routing in a control
-           plane and execute entanglement swapping instead of forwarding in
-           a data plane. Such quantum networks are "routing and swapping" networks.
-           In "routing and swapping" networks, we do not need to care about
+           Classical networks store data coming from an interface, then forward
+           the data to another appropreate interface.
+           Quantum networks store a couple of half Bell pairs, then
+           execute entanglement swapping instead of forwarding in a data plane.
+           Such quantum networks are "store and swap" networks.
+           In "store and swap" networks, we do not need to care about
            the order of generating link Bell pairs since Bell pairs are
            undirected resources. This distinction makes control algorithms and
            optimization of quantum networks different from classical ones.
-           Additionally, "routing and swapping" quantum networks are not
-           "store and forward" networks.
            <vspace blankLines="1" />
 
-           Technically, entanglement swapping first generates a large entangled
-           state among four qubits over three nodes and then measures
-           two qubits in the middle node to leave a Bell pair between
-           two distant nodes. In this sense, "routing and swapping" networks
-           also belong to "routing and measuring" networks.
-           Entanglement swapping is a specific algorithm for a set of Bell pairs.
-           More algorithms to build a quantum network from Bell pairs
-           have been proposed. "Routing and measuring" is a broader category,
-           and more types of quantum networks will be categorized into it.
-           <vspace blankLines="1" />
-
-           Meanwhile, quantum networks of direct transmission are "routing
-           and forwarding" networks. Such quantum networks can carry
-           arbitrary states hop by hop, therefore they are also
-           "store and forward" networks. Hence this later generation of
+           Meanwhile, third generations of quantum networks of direct transmission
+           are "store and forward" networks, since such quantum networks can carry
+           arbitrary states hop by hop. Hence those later generations of
            quantum networks would have more in common with classical networks
            than the first quantum networks in networking algorithms.</t>
            

--- a/draft-irtf-qirg-principles-03.xml
+++ b/draft-irtf-qirg-principles-03.xml
@@ -939,8 +939,8 @@
            execute entanglement swapping instead of forwarding in the data plane.
            Such quantum networks are "store and swap" networks.
            In "store and swap" networks, we do not need to care about
-           the order of generating link Bell pairs since Bell pairs are
-           undirected resources. This distinction makes control algorithms and
+           the order in which the Bell pairs were generated since they are
+           undirected. This distinction makes control algorithms and
            optimization of quantum networks different from classical ones.
            <vspace blankLines="1" />
 


### PR DESCRIPTION
Bell pairs are undirected network resources. This fact causes many differences between quantum network architectures and classical network architectures. It should be worth clarifying.